### PR TITLE
Make ecs platform alb.load_balancer_arn optional

### DIFF
--- a/builtin/aws/ecs/platform.go
+++ b/builtin/aws/ecs/platform.go
@@ -2742,7 +2742,7 @@ type ALBConfig struct {
 
 	// When set, waypoint will configure the target group into the load balancer.
 	// This allows for usage of existing ALBs.
-	LoadBalancerArn string `hcl:"load_balancer_arn"`
+	LoadBalancerArn string `hcl:"load_balancer_arn,optional"`
 
 	// Indicates, when creating an ALB, that it should be internal rather than
 	// internet facing.


### PR DESCRIPTION
Updates the ecs platform plugin to make `alb.load_balancer_arn` optional as per comment here: https://github.com/hashicorp/waypoint/issues/4680#issuecomment-1551731412

Fixes: https://github.com/hashicorp/waypoint/issues/4680